### PR TITLE
Add SQLAlchemy connection pool customization, readyz route

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -8,18 +8,28 @@ on:
       - '[0-9]+.[0-9]+.[0-9]+'
   pull_request:
 
+permissions:
+  contents: read
 jobs:
   publish-production:
 
     runs-on: ubuntu-24.04
 
     steps:
-      - uses: actions/checkout@v4
-      - name: Publish to Registry
-        uses: docker/build-push-action@v1
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: Log in to Docker Hub
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
         with:
           username: ${{ secrets.pcicdevops_at_dockerhub_username }}
           password: ${{ secrets.pcicdevops_at_dockerhub_password }}
-          dockerfile: ./docker/production/Dockerfile
-          repository: pcic/ncwms-mm-rproxy
-          tag_with_ref: true
+
+      - name: Publish to Registry
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          file: ./docker/production/Dockerfile
+          push: true
+          tags: |
+            pcic/ncwms-mm-rproxy:${{ github.ref_name }}
+            ${{ github.ref_name == 'master' && 'pcic/ncwms-mm-rproxy:latest' || '' }}

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,13 +6,11 @@ on:
       - '*'
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
-  pull_request:
 
 permissions:
   contents: read
 jobs:
   publish-production:
-
     runs-on: ubuntu-24.04
 
     steps:

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -7,7 +7,10 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-24.04
-
+    timeout-minutes: 15
+    concurrency:
+      group: ${{ github.workflow }}-${{ github.ref }}-${{ matrix.python-version }}
+      cancel-in-progress: true
     strategy:
       matrix:
         python-version: ["3.11", "3.12"]

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -2,6 +2,8 @@ name: Python CI
 
 on: push
 
+permissions:
+  contents: read
 jobs:
   test:
     runs-on: ubuntu-24.04
@@ -11,10 +13,12 @@ jobs:
         python-version: ["3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/docker/development/flask.config.dictcache.py
+++ b/docker/development/flask.config.dictcache.py
@@ -1,6 +1,6 @@
 """
-Values in this file update the Flask configuration, which can include 
-configuration values for any plugin (e.g., Flask-SQLAlchemy) and this app 
+Values in this file update the Flask configuration, which can include
+configuration values for any plugin (e.g., Flask-SQLAlchemy) and this app
 itself.
 See https://flask.palletsprojects.com/en/1.1.x/config/, and in particular
 https://flask.palletsprojects.com/en/1.1.x/config/#builtin-configuration-values
@@ -9,26 +9,45 @@ https://flask.palletsprojects.com/en/1.1.x/config/#builtin-configuration-values
 # TODO: Are convenience settings via environment variables a good idea?
 #  Convenient for development.
 import os
+from typing import Any
 from cachetools import LRUCache, LFUCache
+from sqlalchemy.pool import NullPool
+
+
+def build_engine_options() -> dict[str, Any]:
+    """Build SQLAlchemy engine options from environment variables."""
+    if os.getenv("SQLALCHEMY_POOL_CLASS", "").lower() == "null":
+        return {"poolclass": NullPool}
+
+    options: dict[str, Any] = {"pool_pre_ping": True}
+
+    for env_var, key, cast in [
+        ("SQLALCHEMY_POOL_SIZE", "pool_size", int),
+        ("SQLALCHEMY_MAX_OVERFLOW", "max_overflow", int),
+        ("SQLALCHEMY_POOL_TIMEOUT", "pool_timeout", float),
+        ("SQLALCHEMY_POOL_RECYCLE", "pool_recycle", float),
+    ]:
+        value = os.getenv(env_var)
+        if value is not None:
+            options[key] = cast(value)
+
+    return options
+
 
 # SQLAlchemy configuration
 
 # Note: setting via env var.
 SQLALCHEMY_DATABASE_URI = os.getenv(
-    "MM_DSN", "postgresql://ce_meta_ro@db3.pcic.uvic.ca/ce_meta_12f290b63791"
+    "MM_DSN", "postgresql://httpd_meta@dev-pgbouncer_pgbouncer:5432/pcic_meta"
 )
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False
-SQLALCHEMY_ENGINE_OPTIONS = dict(
-    echo_pool="debug", pool_size=20, pool_recycle=3600
-)
+SQLALCHEMY_ENGINE_OPTIONS = build_engine_options()
 
 # Translation app configuration
 
 # Note: setting via env var.
-NCWMS_URL = os.getenv(
-    "NCWMS_URL", "https://services.pacificclimate.org/dev/ncwms"
-)
+NCWMS_URL = os.getenv("NCWMS_URL", "https://services.pacificclimate.org/dev/ncwms")
 NCWMS_LAYER_PARAM_NAMES = {"layers", "layer", "layername", "query_layers"}
 NCWMS_DATASET_PARAM_NAMES = {"dataset"}
 

--- a/docker/development/flask.config.lrucache.py
+++ b/docker/development/flask.config.lrucache.py
@@ -9,19 +9,39 @@ https://flask.palletsprojects.com/en/1.1.x/config/#builtin-configuration-values
 # TODO: Are convenience settings via environment variables a good idea?
 #  Convenient for development.
 import os
+from typing import Any
 from cachetools import LRUCache, LFUCache
+from sqlalchemy.pool import NullPool
+
+
+def build_engine_options() -> dict[str, Any]:
+    """Build SQLAlchemy engine options from environment variables."""
+    if os.getenv("SQLALCHEMY_POOL_CLASS", "").lower() == "null":
+        return {"poolclass": NullPool}
+
+    options: dict[str, Any] = {"pool_pre_ping": True}
+
+    for env_var, key, cast in [
+        ("SQLALCHEMY_POOL_SIZE", "pool_size", int),
+        ("SQLALCHEMY_MAX_OVERFLOW", "max_overflow", int),
+        ("SQLALCHEMY_POOL_TIMEOUT", "pool_timeout", float),
+        ("SQLALCHEMY_POOL_RECYCLE", "pool_recycle", float),
+    ]:
+        value = os.getenv(env_var)
+        if value is not None:
+            options[key] = cast(value)
+
+    return options
 
 # SQLAlchemy configuration
 
 # Note: setting via env var.
 SQLALCHEMY_DATABASE_URI = os.getenv(
-    "MM_DSN", "postgresql://ce_meta_ro@db3.pcic.uvic.ca/ce_meta_12f290b63791"
+    "MM_DSN", "postgresql://httpd_meta@dev-pgbouncer_pgbouncer:5432/pcic_meta"
 )
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False
-SQLALCHEMY_ENGINE_OPTIONS = dict(
-    echo_pool="debug", pool_size=20, pool_recycle=3600
-)
+SQLALCHEMY_ENGINE_OPTIONS = build_engine_options()
 
 # Translation app configuration
 

--- a/docker/development/flask.config.nocache.py
+++ b/docker/development/flask.config.nocache.py
@@ -1,6 +1,6 @@
 """
-Values in this file update the Flask configuration, which can include 
-configuration values for any plugin (e.g., Flask-SQLAlchemy) and this app 
+Values in this file update the Flask configuration, which can include
+configuration values for any plugin (e.g., Flask-SQLAlchemy) and this app
 itself.
 See https://flask.palletsprojects.com/en/1.1.x/config/, and in particular
 https://flask.palletsprojects.com/en/1.1.x/config/#builtin-configuration-values
@@ -9,26 +9,45 @@ https://flask.palletsprojects.com/en/1.1.x/config/#builtin-configuration-values
 # TODO: Are convenience settings via environment variables a good idea?
 #  Convenient for development.
 import os
+from typing import Any
 from cachetools import LRUCache, LFUCache
+from sqlalchemy.pool import NullPool
+
+
+def build_engine_options() -> dict[str, Any]:
+    """Build SQLAlchemy engine options from environment variables."""
+    if os.getenv("SQLALCHEMY_POOL_CLASS", "").lower() == "null":
+        return {"poolclass": NullPool}
+
+    options: dict[str, Any] = {"pool_pre_ping": True}
+
+    for env_var, key, cast in [
+        ("SQLALCHEMY_POOL_SIZE", "pool_size", int),
+        ("SQLALCHEMY_MAX_OVERFLOW", "max_overflow", int),
+        ("SQLALCHEMY_POOL_TIMEOUT", "pool_timeout", float),
+        ("SQLALCHEMY_POOL_RECYCLE", "pool_recycle", float),
+    ]:
+        value = os.getenv(env_var)
+        if value is not None:
+            options[key] = cast(value)
+
+    return options
+
 
 # SQLAlchemy configuration
 
 # Note: setting via env var.
 SQLALCHEMY_DATABASE_URI = os.getenv(
-    "MM_DSN", "postgresql://ce_meta_ro@db3.pcic.uvic.ca/ce_meta_12f290b63791"
+    "MM_DSN", "postgresql://httpd_meta@dev-pgbouncer_pgbouncer:5432/pcic_meta"
 )
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False
-SQLALCHEMY_ENGINE_OPTIONS = dict(
-    echo_pool="debug", pool_size=20, pool_recycle=3600
-)
+SQLALCHEMY_ENGINE_OPTIONS = build_engine_options()
 
 # Translation app configuration
 
 # Note: setting via env var.
-NCWMS_URL = os.getenv(
-    "NCWMS_URL", "https://services.pacificclimate.org/dev/ncwms"
-)
+NCWMS_URL = os.getenv("NCWMS_URL", "https://services.pacificclimate.org/dev/ncwms")
 NCWMS_LAYER_PARAM_NAMES = {"layers", "layer", "layername", "query_layers"}
 NCWMS_DATASET_PARAM_NAMES = {"dataset"}
 

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -1,18 +1,13 @@
-FROM ubuntu:24.04
-
-LABEL maintainer="Rod Glover <rglover@uvic.ca>"
+FROM ubuntu:24.04 AS builder
 
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get -yq install \
     build-essential \
-    curl \
     libpq-dev \
     pipx \
     python3 \
-    python3-dev \
-    python3-pip \
-    postgresql-client && \
+    python3-dev && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -22,10 +17,32 @@ ENV PATH="/root/.local/bin:$PATH"
 
 RUN pipx install poetry
 
-COPY . .
+COPY pyproject.toml poetry.lock README.md ./
+COPY ncwms_mm_rproxy ./ncwms_mm_rproxy
+COPY docker/production ./docker/production
 
 RUN poetry config virtualenvs.in-project true && \
-    poetry install
+    poetry install --only main
+
+FROM ubuntu:24.04
+
+LABEL maintainer="PCIC DevOps <pcic.devops@uvic.ca>"
+
+ARG DEBIAN_FRONTEND=noninteractive
+RUN apt-get update && \
+    apt-get -yq install \
+    curl \
+    libpq5 \
+    python3 \
+    postgresql-client && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+COPY --from=builder /app /app
+
+ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 8000
 
@@ -36,4 +53,4 @@ RUN groupadd -g 999 user \
     && useradd -r -u 999 -g user user
 USER user
 
-ENTRYPOINT ["poetry", "run", "gunicorn", "-c", "./docker/production/gunicorn.config.py", "ncwms_mm_rproxy.wsgi:app"]
+ENTRYPOINT ["gunicorn", "-c", "./docker/production/gunicorn.config.py", "ncwms_mm_rproxy.wsgi:app"]

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && \
     apt-get -yq install \
     curl \
     libpq-dev \
+    pipx \
     python3 \
     python3-dev \
     python3-pip \
@@ -16,10 +17,9 @@ RUN apt-get update && \
 
 WORKDIR /app
 
-ENV POETRY_HOME="/opt/poetry"
-ENV PATH="$POETRY_HOME/bin:$PATH"
+ENV PATH="/root/.local/bin:$PATH"
 
-RUN curl -sSL https://install.python-poetry.org | python3
+RUN pipx install poetry
 
 COPY . .
 
@@ -27,6 +27,9 @@ RUN poetry config virtualenvs.in-project true && \
     poetry install
 
 EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+    CMD curl -f http://localhost:8000/readyz || exit 1
 
 RUN groupadd -g 999 user \
     && useradd -r -u 999 -g user user

--- a/docker/production/Dockerfile
+++ b/docker/production/Dockerfile
@@ -5,6 +5,7 @@ LABEL maintainer="Rod Glover <rglover@uvic.ca>"
 ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && \
     apt-get -yq install \
+    build-essential \
     curl \
     libpq-dev \
     pipx \

--- a/ncwms_mm_rproxy/__init__.py
+++ b/ncwms_mm_rproxy/__init__.py
@@ -2,10 +2,11 @@ import os
 import logging.config
 from time import perf_counter, sleep
 
-from flask import Flask, request, Response
+from flask import Flask, jsonify, request, Response
 from flask_cors import CORS
 from flask_sqlalchemy import SQLAlchemy
 import requests
+from sqlalchemy import text
 
 from ncwms_mm_rproxy.translation import Translation
 
@@ -228,9 +229,23 @@ def create_app(test_config=None):
     def handle_no_translation(e):
         return e.args[0], 404
 
-    @app.route("/health", methods=["GET"])
-    def health():
-        return "OK", 200
+    @app.route("/readyz", methods=["GET"])
+    def readyz():
+        status = {"status": "ok"}
+        http_status = 200
+
+        if request.args.get("verbose", "").lower() in {"1", "true", "yes"}:
+            try:
+                db.session.execute(text("SELECT 1"))
+                status["db"] = "ok"
+            except Exception as exc:
+                status["status"] = "error"
+                status["db"] = str(exc)
+                http_status = 503
+
+        response = jsonify(status)
+        response.cache_control.no_store = True
+        return response, http_status
 
     return app
 

--- a/ncwms_mm_rproxy/flask.config.py
+++ b/ncwms_mm_rproxy/flask.config.py
@@ -1,30 +1,51 @@
 """
-Values in this file update the Flask configuration, which can include 
-configuration values for any plugin (e.g., Flask-SQLAlchemy) and this app 
+Values in this file update the Flask configuration, which can include
+configuration values for any plugin (e.g., Flask-SQLAlchemy) and this app
 itself.
 See https://flask.palletsprojects.com/en/1.1.x/config/, and in particular
 https://flask.palletsprojects.com/en/1.1.x/config/#builtin-configuration-values
 """
+
 import os
+from typing import Any
+
+from sqlalchemy.pool import NullPool
+
+
+def build_engine_options() -> dict[str, Any]:
+    """Build SQLAlchemy engine options from environment variables."""
+    if os.getenv("SQLALCHEMY_POOL_CLASS", "").lower() == "null":
+        return {"poolclass": NullPool}
+
+    options: dict[str, Any] = {"pool_pre_ping": True}
+
+    for env_var, key, cast in [
+        ("SQLALCHEMY_POOL_SIZE", "pool_size", int),
+        ("SQLALCHEMY_MAX_OVERFLOW", "max_overflow", int),
+        ("SQLALCHEMY_POOL_TIMEOUT", "pool_timeout", float),
+        ("SQLALCHEMY_POOL_RECYCLE", "pool_recycle", float),
+    ]:
+        value = os.getenv(env_var)
+        if value is not None:
+            options[key] = cast(value)
+
+    return options
+
 
 # SQLAlchemy configuration
 
 # Note: setting via env var.
 SQLALCHEMY_DATABASE_URI = os.getenv(
-    "MM_DSN", "postgresql://ce_meta_ro@db3.pcic.uvic.ca/ce_meta_12f290b63791"
+    "MM_DSN", "postgresql://httpd_meta@dev-pgbouncer_pgbouncer:5432/pcic_meta"
 )
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 SQLALCHEMY_ECHO = False
-SQLALCHEMY_ENGINE_OPTIONS = dict(
-    echo_pool="debug", pool_size=20, pool_recycle=3600
-)
+SQLALCHEMY_ENGINE_OPTIONS = build_engine_options()
 
 # Translation app configuration
 # See README for explanations.
 
-NCWMS_URL = os.getenv(
-    "NCWMS_URL", "https://services.pacificclimate.org/dev/ncwms"
-)
+NCWMS_URL = os.getenv("NCWMS_URL", "https://services.pacificclimate.org/dev/ncwms")
 NCWMS_LAYER_PARAM_NAMES = {"layers", "layer", "layername", "query_layers"}
 NCWMS_DATASET_PARAM_NAMES = {"dataset"}
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,5 +1,6 @@
 import pytest
 from unittest.mock import patch, MagicMock
+from sqlalchemy.exc import SQLAlchemyError
 from ncwms_mm_rproxy import create_app
 
 
@@ -27,10 +28,28 @@ def client(app):
 
 
 class TestAppEndpoints:
-    def test_healthz(self, client):
-        response = client.get("/health")
+    def test_readyz(self, client):
+        response = client.get("/readyz")
         assert response.status_code == 200
-        assert response.data == b"OK"
+        assert response.get_json() == {"status": "ok"}
+        assert response.cache_control.no_store is True
+
+    def test_readyz_verbose_checks_db(self, client):
+        response = client.get("/readyz?verbose=true")
+        assert response.status_code == 200
+        assert response.get_json() == {"status": "ok", "db": "ok"}
+
+    @patch("ncwms_mm_rproxy.db.session.execute")
+    def test_readyz_verbose_returns_503_on_db_error(self, mock_execute, client):
+        mock_execute.side_effect = SQLAlchemyError("db unavailable")
+
+        response = client.get("/readyz?verbose=true")
+
+        assert response.status_code == 503
+        assert response.get_json() == {
+            "status": "error",
+            "db": "db unavailable",
+        }
 
     @patch("ncwms_mm_rproxy.requests.get")
     def test_dynamic_success_response(self, mock_get, client):


### PR DESCRIPTION
Follows [SDPB-#93](https://github.com/pacificclimate/station-data-portal-backend/pull/93/changes): 
- Allows customization of the Sqlalchemy connection pool for use with PGBouncer
- Replaces `/health` with `/readyz`
- Includes CI maintenance updates
- Installs `poetry` with `pipx`